### PR TITLE
Replacement of 'git ls-files' with Dir.glob

### DIFF
--- a/acts_as_silent_list.gemspec
+++ b/acts_as_silent_list.gemspec
@@ -14,9 +14,8 @@ Gem::Specification.new do |s|
   s.description = %q{This "acts_as" extension is a clone of the well known acts_as_list, only it avoids triggering active record callbacks.}
 
   # Load Paths...
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir.glob('lib/**/*') + %w(init.rb MIT-LICENSE README.rdoc)
+  s.test_files    = Dir.glob('test/**/*')
   s.require_paths = ['lib']
 
   # Dependencies (installed via 'bundle install')...


### PR DESCRIPTION
[`* `#15067` FATAL: NOT A GIT REPOSITORY" WARNINGS`](https://www.openproject.org/work_packages/15067)

Using 'git ls-files' in *.gemspec is a bad practice. So I changed it to use 'Dir.glob'.
